### PR TITLE
Fix unary operator bug

### DIFF
--- a/remove
+++ b/remove
@@ -48,6 +48,6 @@ if [ -f /usr/bin/alienware-kbl ]; then
 	rm -f /usr/bin/alienware-kbl
 fi
 
-if [ $1 != "-s" ]; then
+if [ "$1" != "-s" ]; then
 	echo -e "\e[00;32mAlienware-KBL has been removed.\e[00m"
 fi


### PR DESCRIPTION
Previously, when running this script, the output would complain that:
`./remove: line 51: [: !=: unary operator expected`.

This is likely because the variable `$1` was not enclosed in double quotes,
so that when bash substitutes this variable it is evaluated literally, rather than
as a string.

Accordingly, wrap `$1` in double quotes, so that a string comparison results.